### PR TITLE
Add Custom User model and Users app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ __pycache__/
 
 # Python Virtual Environment
 .venv/
+
+# Databases
+*.sqlite3
+
+# Migrations the may be made during testing and creation of models.
+**/migrations/

--- a/payroll_manager/settings.py
+++ b/payroll_manager/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'users.apps.UsersConfig',
 ]
 
 MIDDLEWARE = [
@@ -121,3 +122,5 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+AUTH_USER_MODEL = 'users.CustomUser'

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,0 +1,20 @@
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+
+from users.models import CustomUser
+
+
+# Register your models here.
+class CustomUserAdmin(UserAdmin):
+    """
+    Helps to access Django's built-in web interface for database.
+    :param list_display: the details to be shown in overview (without opening individual record)
+    :param fieldsets: groups of fields (how to show them, how to group them under a heading)
+    """
+    model = CustomUser
+    list_display = ("username", "email", "role", "is_staff", "is_active")
+    fieldsets = UserAdmin.fieldsets + (
+        (None, {"fields" : ("role", "phone_number")}),
+    )
+
+admin.site.register(CustomUser, CustomUserAdmin)

--- a/users/apps.py
+++ b/users/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class UsersConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'users'

--- a/users/custom_managers.py
+++ b/users/custom_managers.py
@@ -1,0 +1,19 @@
+from django.contrib.auth.base_user import BaseUserManager
+
+class UserManager(BaseUserManager):
+    use_in_migrations = True
+
+    def create_user(self, username, email, password=None, role="EMPLOYEE", **extra_fields):
+        if not email:
+            raise ValueError("Users must have an email address")
+        email = self.normalize_email(email)
+        user = self.model(username=username, email=email, role=role, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_superuser(self, username, email, password, **extra_fields):
+        extra_fields.setdefault('role', 'ADMIN')
+        extra_fields.setdefault('is_staff', True)
+        extra_fields.setdefault('is_superuser', True)
+        return self.create_user(username, email, password, **extra_fields)

--- a/users/models.py
+++ b/users/models.py
@@ -1,0 +1,36 @@
+from django.contrib.auth.models import AbstractUser
+from django.db import models
+
+from users.custom_managers import UserManager
+
+
+# Create your models here.
+
+class Role(models.TextChoices):
+    ADMIN = "ADMIN", "Admin"
+    HR = "HR", "HR"
+    EMPLOYEE = "EMPLOYEE", "Employee"
+
+class CustomUser(AbstractUser):
+    first_name = models.CharField(max_length=25, blank=True)
+    last_name = models.CharField(max_length=25, blank=True)
+    email = models.EmailField(unique=True, blank=True)
+    phone_number = models.CharField(max_length=11, blank=True)
+    username = models.CharField(max_length=11, unique=True, blank=False, null=False)
+    role = models.CharField(choices=Role.choices, max_length=20, default=Role.EMPLOYEE)
+
+    USERNAME_FIELD = 'username'
+    REQUIRED_FIELDS = ['email']
+
+    objects = UserManager()
+
+    def is_admin(self):
+        return self.role == Role.ADMIN
+    def is_hr(self):
+        return self.role == Role.HR
+    def is_employee(self):
+        return self.role == Role.EMPLOYEE
+    def __str__(self):
+        return self.username
+    def __repr__(self):
+        return self.username

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,0 +1,3 @@
+from django.test import TestCase
+
+# Create your tests here.

--- a/users/views.py
+++ b/users/views.py
@@ -1,0 +1,3 @@
+from django.shortcuts import render
+
+# Create your views here.


### PR DESCRIPTION
- Introduced a new 'users' app
  - with a custom user model `CustomUser`
  - supporting roles (Admin, HR, Employee)
  - custom user manager
  - and admin integration 
- Updated `settings` to use the new user model and registered the app.
- Updated `.gitignore` to exclude SQLite databases and migration files initially until fixed user model.