### PR TITLE
Add reports dashboard with analytics and payslip distribution modal

### DIFF
--- a/payroll_manager/urls.py
+++ b/payroll_manager/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
     path('', include('core.urls')),
     path('employees/', include('employees.urls')),
     path('payroll/', include('payroll.urls')),
+    path('reports/', include('reports.urls')),
 ]

--- a/reports/urls.py
+++ b/reports/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from reports import views
+
+urlpatterns = [
+    path('', views.reports_dashboard, name='reports_dashboard'),
+]
+

--- a/reports/views.py
+++ b/reports/views.py
@@ -1,3 +1,165 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
+from django.contrib.auth.decorators import login_required
+from django.contrib import messages
+from django.db.models import Sum, Count, Avg
+from employees.models import Employee
+from payroll.models import Payslip, Payroll, PayslipAllowance, PayslipDeduction
+from datetime import datetime, timedelta
+from decimal import Decimal
+import json
 
-# Create your views here.
+
+@login_required
+def reports_dashboard(request):
+    """Reports dashboard with charts and visualizations - only HR and Admin can access"""
+    user = request.user
+    
+    # Check if user is HR or Admin
+    if not (user.is_hr() or user.is_admin()):
+        messages.error(request, 'You do not have permission to access this page.')
+        return redirect('dashboard')
+    
+    # Get date range (last 12 months by default)
+    end_date = datetime.now()
+    start_date = end_date - timedelta(days=365)
+    
+    # 1. Payroll Trends Over Time (Monthly)
+    payrolls = Payroll.objects.filter(
+        processed_date__gte=start_date
+    ).order_by('year', 'month')
+    
+    monthly_payroll_data = []
+    monthly_labels = []
+    for payroll in payrolls:
+        month_name = datetime(payroll.year, payroll.month, 1).strftime('%b %Y')
+        monthly_labels.append(month_name)
+        monthly_payroll_data.append({
+            'gross_salary': float(payroll.total_gross_salary),
+            'deductions': float(payroll.total_deductions),
+            'net_salary': float(payroll.total_net_salary),
+            'employee_count': payroll.employee_count,
+        })
+    
+    # 2. Department-wise Employee Distribution
+    dept_data = Employee.objects.values('job_role__department').annotate(
+        count=Count('id')
+    ).order_by('-count')
+    
+    dept_labels = [item['job_role__department'] or 'No Department' for item in dept_data]
+    dept_counts = [item['count'] for item in dept_data]
+    
+    # 3. Salary Distribution by Department
+    salary_by_dept = Employee.objects.values('job_role__department').annotate(
+        avg_salary=Avg('salary_base'),
+        total_employees=Count('id')
+    ).order_by('-avg_salary')
+    
+    salary_dept_labels = [item['job_role__department'] or 'No Department' for item in salary_by_dept]
+    salary_dept_avg = [float(item['avg_salary']) for item in salary_by_dept]
+    
+    # 4. Top Allowance Types (from recent payslips)
+    recent_payslips = Payslip.objects.filter(
+        payroll__processed_date__gte=start_date
+    ).select_related('payroll')
+    
+    allowance_totals = PayslipAllowance.objects.filter(
+        payslip__in=recent_payslips
+    ).values('allowance_type__name').annotate(
+        total_amount=Sum('amount')
+    ).order_by('-total_amount')[:10]
+    
+    allowance_labels = [item['allowance_type__name'] for item in allowance_totals]
+    allowance_amounts = [float(item['total_amount']) for item in allowance_totals]
+    
+    # 5. Top Deduction Types (from recent payslips)
+    deduction_totals = PayslipDeduction.objects.filter(
+        payslip__in=recent_payslips
+    ).values('deduction_type__name').annotate(
+        total_amount=Sum('amount')
+    ).order_by('-total_amount')[:10]
+    
+    deduction_labels = [item['deduction_type__name'] for item in deduction_totals]
+    deduction_amounts = [float(item['total_amount']) for item in deduction_totals]
+    
+    # 6. Job Role Distribution
+    job_role_data = Employee.objects.values('job_role__title').annotate(
+        count=Count('id')
+    ).order_by('-count')[:10]
+    
+    job_role_labels = [item['job_role__title'] or 'No Role' for item in job_role_data]
+    job_role_counts = [item['count'] for item in job_role_data]
+    
+    # 7. Overall Statistics
+    total_employees = Employee.objects.count()
+    total_payrolls = Payroll.objects.count()
+    total_payslips = Payslip.objects.count()
+    
+    # Calculate total payroll amounts
+    total_gross = Payroll.objects.aggregate(Sum('total_gross_salary'))['total_gross_salary__sum'] or Decimal('0.00')
+    total_deductions = Payroll.objects.aggregate(Sum('total_deductions'))['total_deductions__sum'] or Decimal('0.00')
+    total_net = Payroll.objects.aggregate(Sum('total_net_salary'))['total_net_salary__sum'] or Decimal('0.00')
+    
+    # Average salary
+    avg_salary = Employee.objects.aggregate(Avg('salary_base'))['salary_base__avg'] or Decimal('0.00')
+    
+    # 8. Recent Payroll Activity (Last 6 months)
+    recent_months = []
+    recent_gross = []
+    recent_net = []
+    
+    for i in range(6, 0, -1):
+        month_date = end_date - timedelta(days=30 * i)
+        month_payrolls = Payroll.objects.filter(
+            year=month_date.year,
+            month=month_date.month
+        )
+        if month_payrolls.exists():
+            payroll = month_payrolls.first()
+            recent_months.append(month_date.strftime('%b %Y'))
+            recent_gross.append(float(payroll.total_gross_salary))
+            recent_net.append(float(payroll.total_net_salary))
+        else:
+            recent_months.append(month_date.strftime('%b %Y'))
+            recent_gross.append(0)
+            recent_net.append(0)
+    
+    context = {
+        'user': user,
+        'name': user.first_name or user.username,
+        'is_hr_or_admin': True,
+        'active_nav': 'reports',
+        
+        # Statistics
+        'total_employees': total_employees,
+        'total_payrolls': total_payrolls,
+        'total_payslips': total_payslips,
+        'total_gross': total_gross,
+        'total_deductions': total_deductions,
+        'total_net': total_net,
+        'avg_salary': avg_salary,
+        
+        # Chart Data (as JSON for JavaScript)
+        'monthly_labels': json.dumps(monthly_labels),
+        'monthly_payroll_data': json.dumps(monthly_payroll_data),
+        
+        'dept_labels': json.dumps(dept_labels),
+        'dept_counts': json.dumps(dept_counts),
+        
+        'salary_dept_labels': json.dumps(salary_dept_labels),
+        'salary_dept_avg': json.dumps(salary_dept_avg),
+        
+        'allowance_labels': json.dumps(allowance_labels),
+        'allowance_amounts': json.dumps(allowance_amounts),
+        
+        'deduction_labels': json.dumps(deduction_labels),
+        'deduction_amounts': json.dumps(deduction_amounts),
+        
+        'job_role_labels': json.dumps(job_role_labels),
+        'job_role_counts': json.dumps(job_role_counts),
+        
+        'recent_months': json.dumps(recent_months),
+        'recent_gross': json.dumps(recent_gross),
+        'recent_net': json.dumps(recent_net),
+    }
+    
+    return render(request, 'reports/dashboard.html', context)

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -79,7 +79,7 @@
                     <p class="text-slate-400 text-sm">Calculate salaries</p>
                 </div>
             </a>
-            <a href="#" class="flex items-center p-4 bg-slate-800 rounded-lg hover:bg-slate-700 transition">
+            <a href="{% url 'reports_dashboard' %}" class="flex items-center p-4 bg-slate-800 rounded-lg hover:bg-slate-700 transition">
                 <div class="w-10 h-10 bg-purple-600 rounded-lg flex items-center justify-center mr-4">
                     <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>

--- a/templates/employees/my_payslips.html
+++ b/templates/employees/my_payslips.html
@@ -22,7 +22,13 @@
                 </thead>
                 <tbody>
                     {% for payslip in payslips %}
-                    <tr class="border-b border-slate-800 hover:bg-slate-800 transition">
+                    <tr class="border-b border-slate-800 hover:bg-slate-800 transition" 
+                        data-payslip-id="{{ payslip.id }}"
+                        data-base-salary="{{ payslip.base_salary }}"
+                        data-gross-salary="{{ payslip.gross_salary }}"
+                        data-total-deductions="{{ payslip.total_deductions }}"
+                        data-net-salary="{{ payslip.net_salary }}"
+                        data-period="{{ payslip.payroll.month }}/{{ payslip.payroll.year }}">
                         <td class="py-4 px-6 text-white font-medium">{{ payslip.payroll.month }}/{{ payslip.payroll.year }}</td>
                         <td class="py-4 px-6 text-slate-300">₹{{ payslip.base_salary|floatformat:2 }}</td>
                         <td class="py-4 px-6 text-slate-300">₹{{ payslip.gross_salary|floatformat:2 }}</td>
@@ -38,9 +44,19 @@
                             </span>
                         </td>
                         <td class="py-4 px-6">
-                            <a href="{% url 'view_payslip_detail' payslip.id %}" class="text-indigo-400 hover:text-indigo-300 font-medium">
-                                View Details
-                            </a>
+                            <div class="flex items-center gap-3">
+                                <a href="{% url 'view_payslip_detail' payslip.id %}" class="text-indigo-400 hover:text-indigo-300 font-medium">
+                                    View Details
+                                </a>
+                                <button 
+                                    onclick="openPayslipDistributionModal({{ payslip.id }})" 
+                                    class="text-purple-400 hover:text-purple-300 font-medium flex items-center gap-1">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
+                                    </svg>
+                                    Distribution
+                                </button>
+                            </div>
                         </td>
                     </tr>
                     {% endfor %}
@@ -57,4 +73,72 @@
         <p class="text-slate-400">You don't have any payslips yet. Payslips will appear here once payroll is processed.</p>
     </div>
 {% endif %}
+
+{% if payslips %}
+<!-- Payslip Data for JavaScript -->
+<script type="application/json" id="payslipsData">
+{
+    "payslips": [
+        {% for payslip in payslips %}
+        {
+            "id": {{ payslip.id }},
+            "baseSalary": {{ payslip.base_salary }},
+            "grossSalary": {{ payslip.gross_salary }},
+            "totalDeductions": {{ payslip.total_deductions }},
+            "netSalary": {{ payslip.net_salary }},
+            "period": "{{ payslip.payroll.month }}/{{ payslip.payroll.year }}",
+            "allowances": [
+                {% for allowance in payslip.allowances.all %}
+                {
+                    "name": "{{ allowance.allowance_type.name|escapejs }}",
+                    "amount": {{ allowance.amount }}
+                }{% if not forloop.last %},{% endif %}
+                {% endfor %}
+            ],
+            "deductions": [
+                {% for deduction in payslip.deductions.all %}
+                {
+                    "name": "{{ deduction.deduction_type.name|escapejs }}",
+                    "amount": {{ deduction.amount }}
+                }{% if not forloop.last %},{% endif %}
+                {% endfor %}
+            ]
+        }{% if not forloop.last %},{% endif %}
+        {% endfor %}
+    ]
+}
+</script>
+{% else %}
+<script type="application/json" id="payslipsData">
+{"payslips": []}
+</script>
+{% endif %}
+
+<!-- Include the shared modal component -->
+{% include 'employees/payslip_distribution_modal.html' %}
+
+<script>
+    // Load payslip data for list page
+    let payslipsData = {};
+    try {
+        const dataScript = document.getElementById('payslipsData');
+        if (dataScript) {
+            payslipsData = JSON.parse(dataScript.textContent);
+        }
+    } catch (e) {
+        console.error('Error loading payslip data:', e);
+    }
+
+    // Function to open modal from list page
+    function openPayslipDistributionModal(payslipId) {
+        // Find payslip data
+        const payslip = payslipsData.payslips?.find(p => p.id === payslipId);
+        if (!payslip) {
+            console.error('Payslip not found:', payslipId);
+            return;
+        }
+        // Use the shared function from the modal component
+        openPayslipDistributionModalWithData(payslip);
+    }
+</script>
 {% endblock %}

--- a/templates/employees/payslip_detail.html
+++ b/templates/employees/payslip_detail.html
@@ -128,12 +128,53 @@
         <a href="{% url 'view_my_payslips' %}" class="btn btn-ghost text-slate-300 hover:text-white">
             ← Back to My Payslips
         </a>
-        <a href="{% url 'generate_payslip' payslip.id %}" target="_blank" class="btn bg-indigo-600 text-white hover:bg-indigo-700">
-            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
-            </svg>
-            Generate Payslip
-        </a>
+        <div class="flex items-center gap-3">
+            <button 
+                onclick="openPayslipDistributionModalFromDetail()" 
+                class="btn bg-purple-600 text-white hover:bg-purple-700 flex items-center">
+                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
+                </svg>
+                View Distribution
+            </button>
+            <a href="{% url 'generate_payslip' payslip.id %}" target="_blank" class="btn bg-indigo-600 text-white hover:bg-indigo-700">
+                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+                </svg>
+                Generate Payslip
+            </a>
+        </div>
     </div>
 </div>
+
+<!-- Payslip Data for JavaScript -->
+<script type="application/json" id="payslipDetailData">
+{
+    "id": {{ payslip.id }},
+    "baseSalary": {{ payslip.base_salary }},
+    "grossSalary": {{ payslip.gross_salary }},
+    "totalDeductions": {{ payslip.total_deductions }},
+    "netSalary": {{ payslip.net_salary }},
+    "period": "{{ payslip.payroll.month }}/{{ payslip.payroll.year }}",
+    "allowances": [
+        {% for allowance in allowances %}
+        {
+            "name": "{{ allowance.allowance_type.name|escapejs }}",
+            "amount": {{ allowance.amount }}
+        }{% if not forloop.last %},{% endif %}
+        {% endfor %}
+    ],
+    "deductions": [
+        {% for deduction in deductions %}
+        {
+            "name": "{{ deduction.deduction_type.name|escapejs }}",
+            "amount": {{ deduction.amount }}
+        }{% if not forloop.last %},{% endif %}
+        {% endfor %}
+    ]
+}
+</script>
+
+<!-- Include the modal and chart scripts -->
+{% include 'employees/payslip_distribution_modal.html' %}
 {% endblock %}

--- a/templates/employees/payslip_distribution_modal.html
+++ b/templates/employees/payslip_distribution_modal.html
@@ -1,0 +1,372 @@
+<!-- Payslip Distribution Modal -->
+<div id="payslipDistributionModal" class="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 hidden items-center justify-center p-4">
+    <div class="bg-slate-900 border border-slate-700 rounded-xl max-w-4xl w-full max-h-[90vh] overflow-y-auto">
+        <!-- Modal Header -->
+        <div class="flex items-center justify-between p-6 border-b border-slate-700">
+            <div>
+                <h3 class="text-2xl font-bold text-white">Payslip Distribution</h3>
+                <p class="text-slate-400 mt-1" id="modalPeriod">Pay Period</p>
+            </div>
+            <button onclick="closePayslipDistributionModal()" class="text-slate-400 hover:text-white transition">
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                </svg>
+            </button>
+        </div>
+
+        <!-- Modal Content -->
+        <div class="p-6 space-y-6">
+            <!-- Summary Cards -->
+            <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <div class="bg-slate-800 rounded-lg p-4">
+                    <p class="text-slate-400 text-sm mb-1">Base Salary</p>
+                    <p class="text-white font-bold text-lg" id="modalBaseSalary">₹0</p>
+                </div>
+                <div class="bg-slate-800 rounded-lg p-4">
+                    <p class="text-slate-400 text-sm mb-1">Gross Salary</p>
+                    <p class="text-white font-bold text-lg" id="modalGrossSalary">₹0</p>
+                </div>
+                <div class="bg-slate-800 rounded-lg p-4">
+                    <p class="text-slate-400 text-sm mb-1">Deductions</p>
+                    <p class="text-red-400 font-bold text-lg" id="modalDeductions">₹0</p>
+                </div>
+                <div class="bg-slate-800 rounded-lg p-4">
+                    <p class="text-slate-400 text-sm mb-1">Net Salary</p>
+                    <p class="text-green-400 font-bold text-lg" id="modalNetSalary">₹0</p>
+                </div>
+            </div>
+
+            <!-- Charts Grid -->
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                <!-- Salary Breakdown Pie Chart -->
+                <div class="bg-slate-800 rounded-lg p-6">
+                    <h4 class="text-lg font-semibold text-white mb-4">Salary Breakdown</h4>
+                    <canvas id="salaryBreakdownChart"></canvas>
+                </div>
+
+                <!-- Allowances Distribution -->
+                <div class="bg-slate-800 rounded-lg p-6">
+                    <h4 class="text-lg font-semibold text-white mb-4">Allowances Distribution</h4>
+                    <canvas id="allowancesChart"></canvas>
+                </div>
+
+                <!-- Deductions Distribution -->
+                <div class="bg-slate-800 rounded-lg p-6">
+                    <h4 class="text-lg font-semibold text-white mb-4">Deductions Distribution</h4>
+                    <canvas id="deductionsChart"></canvas>
+                </div>
+
+                <!-- Salary Composition Bar Chart -->
+                <div class="bg-slate-800 rounded-lg p-6">
+                    <h4 class="text-lg font-semibold text-white mb-4">Salary Composition</h4>
+                    <canvas id="salaryCompositionChart"></canvas>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Chart.js Library -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+
+<script>
+    let salaryBreakdownChart = null;
+    let allowancesChart = null;
+    let deductionsChart = null;
+    let salaryCompositionChart = null;
+
+    // Color palette
+    const colorPalette = [
+        '#6366f1', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
+        '#06b6d4', '#ec4899', '#14b8a6', '#f97316', '#84cc16'
+    ];
+
+    function generateColors(count) {
+        const colors = [];
+        for (let i = 0; i < count; i++) {
+            colors.push(colorPalette[i % colorPalette.length]);
+        }
+        return colors;
+    }
+
+    // Function to open modal from detail page
+    function openPayslipDistributionModalFromDetail() {
+        try {
+            const dataScript = document.getElementById('payslipDetailData');
+            if (!dataScript) {
+                console.error('Payslip data not found');
+                return;
+            }
+            const payslip = JSON.parse(dataScript.textContent);
+            openPayslipDistributionModalWithData(payslip);
+        } catch (e) {
+            console.error('Error loading payslip data:', e);
+        }
+    }
+
+    // Function to open modal with payslip data object
+    function openPayslipDistributionModalWithData(payslip) {
+        const baseSalary = payslip.baseSalary;
+        const grossSalary = payslip.grossSalary;
+        const totalDeductions = payslip.totalDeductions;
+        const netSalary = payslip.netSalary;
+        const period = payslip.period;
+        const allowances = payslip.allowances || [];
+        const deductions = payslip.deductions || [];
+
+        // Update modal content
+        document.getElementById('modalPeriod').textContent = `Pay Period: ${period}`;
+        document.getElementById('modalBaseSalary').textContent = '₹' + baseSalary.toLocaleString('en-IN', {minimumFractionDigits: 2});
+        document.getElementById('modalGrossSalary').textContent = '₹' + grossSalary.toLocaleString('en-IN', {minimumFractionDigits: 2});
+        document.getElementById('modalDeductions').textContent = '₹' + totalDeductions.toLocaleString('en-IN', {minimumFractionDigits: 2});
+        document.getElementById('modalNetSalary').textContent = '₹' + netSalary.toLocaleString('en-IN', {minimumFractionDigits: 2});
+
+        // Show modal
+        const modal = document.getElementById('payslipDistributionModal');
+        modal.classList.remove('hidden');
+        modal.classList.add('flex');
+
+        // Destroy existing charts
+        if (salaryBreakdownChart) salaryBreakdownChart.destroy();
+        if (allowancesChart) allowancesChart.destroy();
+        if (deductionsChart) deductionsChart.destroy();
+        if (salaryCompositionChart) salaryCompositionChart.destroy();
+
+        // Create charts
+        setTimeout(() => {
+            createCharts(baseSalary, grossSalary, totalDeductions, netSalary, allowances, deductions);
+        }, 100);
+    }
+
+    function closePayslipDistributionModal() {
+        const modal = document.getElementById('payslipDistributionModal');
+        modal.classList.add('hidden');
+        modal.classList.remove('flex');
+
+        // Destroy charts
+        if (salaryBreakdownChart) {
+            salaryBreakdownChart.destroy();
+            salaryBreakdownChart = null;
+        }
+        if (allowancesChart) {
+            allowancesChart.destroy();
+            allowancesChart = null;
+        }
+        if (deductionsChart) {
+            deductionsChart.destroy();
+            deductionsChart = null;
+        }
+        if (salaryCompositionChart) {
+            salaryCompositionChart.destroy();
+            salaryCompositionChart = null;
+        }
+    }
+
+    // Close modal when clicking outside
+    const modal = document.getElementById('payslipDistributionModal');
+    if (modal) {
+        modal.addEventListener('click', function(e) {
+            if (e.target === this) {
+                closePayslipDistributionModal();
+            }
+        });
+    }
+
+    // Close modal with Escape key
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') {
+            closePayslipDistributionModal();
+        }
+    });
+
+    function createCharts(baseSalary, grossSalary, totalDeductions, netSalary, allowances, deductions) {
+        Chart.defaults.color = '#94a3b8';
+        Chart.defaults.borderColor = '#334155';
+
+        // 1. Salary Breakdown Pie Chart
+        const salaryBreakdownCtx = document.getElementById('salaryBreakdownChart').getContext('2d');
+        const allowancesTotal = allowances.reduce((sum, a) => sum + parseFloat(a.amount), 0);
+        
+        salaryBreakdownChart = new Chart(salaryBreakdownCtx, {
+            type: 'doughnut',
+            data: {
+                labels: ['Base Salary', 'Allowances', 'Deductions'],
+                datasets: [{
+                    data: [baseSalary, allowancesTotal, totalDeductions],
+                    backgroundColor: ['#6366f1', '#10b981', '#ef4444'],
+                    borderColor: '#1e293b',
+                    borderWidth: 2
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: {
+                    legend: {
+                        position: 'bottom',
+                    },
+                    tooltip: {
+                        callbacks: {
+                            label: function(context) {
+                                return context.label + ': ₹' + context.parsed.toLocaleString('en-IN', {minimumFractionDigits: 2});
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        // 2. Allowances Distribution
+        const allowancesContainer = document.getElementById('allowancesChart').parentElement;
+        if (allowances.length > 0) {
+            // Restore canvas if it was replaced
+            if (!allowancesContainer.querySelector('canvas')) {
+                allowancesContainer.innerHTML = '<h4 class="text-lg font-semibold text-white mb-4">Allowances Distribution</h4><canvas id="allowancesChart"></canvas>';
+            }
+            const allowancesCtx = document.getElementById('allowancesChart').getContext('2d');
+            const allowanceLabels = allowances.map(a => a.name);
+            const allowanceAmounts = allowances.map(a => parseFloat(a.amount));
+            
+            allowancesChart = new Chart(allowancesCtx, {
+                type: 'bar',
+                data: {
+                    labels: allowanceLabels,
+                    datasets: [{
+                        label: 'Amount',
+                        data: allowanceAmounts,
+                        backgroundColor: generateColors(allowanceLabels.length).map(c => c + '80'),
+                        borderColor: generateColors(allowanceLabels.length),
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: true,
+                    indexAxis: 'y',
+                    plugins: {
+                        legend: {
+                            display: false
+                        },
+                        tooltip: {
+                            callbacks: {
+                                label: function(context) {
+                                    return '₹' + context.parsed.x.toLocaleString('en-IN', {minimumFractionDigits: 2});
+                                }
+                            }
+                        }
+                    },
+                    scales: {
+                        x: {
+                            beginAtZero: true,
+                            ticks: {
+                                callback: function(value) {
+                                    return '₹' + value.toLocaleString('en-IN');
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        } else {
+            allowancesContainer.innerHTML = '<h4 class="text-lg font-semibold text-white mb-4">Allowances Distribution</h4><div class="text-center text-slate-400 py-8">No allowances</div>';
+        }
+
+        // 3. Deductions Distribution
+        const deductionsContainer = document.getElementById('deductionsChart').parentElement;
+        if (deductions.length > 0) {
+            // Restore canvas if it was replaced
+            if (!deductionsContainer.querySelector('canvas')) {
+                deductionsContainer.innerHTML = '<h4 class="text-lg font-semibold text-white mb-4">Deductions Distribution</h4><canvas id="deductionsChart"></canvas>';
+            }
+            const deductionsCtx = document.getElementById('deductionsChart').getContext('2d');
+            const deductionLabels = deductions.map(d => d.name);
+            const deductionAmounts = deductions.map(d => parseFloat(d.amount));
+            
+            deductionsChart = new Chart(deductionsCtx, {
+                type: 'bar',
+                data: {
+                    labels: deductionLabels,
+                    datasets: [{
+                        label: 'Amount',
+                        data: deductionAmounts,
+                        backgroundColor: generateColors(deductionLabels.length).map(c => c + '80'),
+                        borderColor: generateColors(deductionLabels.length),
+                        borderWidth: 1
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: true,
+                    indexAxis: 'y',
+                    plugins: {
+                        legend: {
+                            display: false
+                        },
+                        tooltip: {
+                            callbacks: {
+                                label: function(context) {
+                                    return '₹' + context.parsed.x.toLocaleString('en-IN', {minimumFractionDigits: 2});
+                                }
+                            }
+                        }
+                    },
+                    scales: {
+                        x: {
+                            beginAtZero: true,
+                            ticks: {
+                                callback: function(value) {
+                                    return '₹' + value.toLocaleString('en-IN');
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        } else {
+            deductionsContainer.innerHTML = '<h4 class="text-lg font-semibold text-white mb-4">Deductions Distribution</h4><div class="text-center text-slate-400 py-8">No deductions</div>';
+        }
+
+        // 4. Salary Composition Bar Chart
+        const salaryCompositionCtx = document.getElementById('salaryCompositionChart').getContext('2d');
+        salaryCompositionChart = new Chart(salaryCompositionCtx, {
+            type: 'bar',
+            data: {
+                labels: ['Base Salary', 'Gross Salary', 'Net Salary'],
+                datasets: [{
+                    label: 'Amount',
+                    data: [baseSalary, grossSalary, netSalary],
+                    backgroundColor: ['#6366f1', '#10b981', '#22c55e'].map(c => c + '80'),
+                    borderColor: ['#6366f1', '#10b981', '#22c55e'],
+                    borderWidth: 1
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: true,
+                plugins: {
+                    legend: {
+                        display: false
+                    },
+                    tooltip: {
+                        callbacks: {
+                            label: function(context) {
+                                return '₹' + context.parsed.y.toLocaleString('en-IN', {minimumFractionDigits: 2});
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    y: {
+                        beginAtZero: true,
+                        ticks: {
+                            callback: function(value) {
+                                return '₹' + value.toLocaleString('en-IN');
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+</script>
+

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -49,7 +49,7 @@
                             Payroll
                         </a>
                         <!-- Reports -->
-                        <a href="#" class="flex items-center px-4 py-3 text-slate-300 rounded-lg hover:bg-slate-800 transition">
+                        <a href="{% url 'reports_dashboard' %}" class="flex items-center px-4 py-3 {% if active_nav == 'reports' %}text-white bg-indigo-600 rounded-lg hover:bg-indigo-700{% else %}text-slate-300 rounded-lg hover:bg-slate-800{% endif %} transition">
                             <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
                             </svg>

--- a/templates/reports/dashboard.html
+++ b/templates/reports/dashboard.html
@@ -1,0 +1,453 @@
+{% extends 'layout.html' %}
+
+{% block page_title %}Reports - Payroll Manager{% endblock %}
+{% block header_title %}Reports & Analytics{% endblock %}
+{% block header_subtitle %}Comprehensive insights into your payroll data{% endblock %}
+
+{% block content %}
+<!-- Statistics Cards -->
+<div class="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+    <div class="bg-slate-900 border border-slate-700 rounded-xl p-6">
+        <div class="flex items-center justify-between">
+            <div>
+                <p class="text-slate-400 text-sm mb-1">Total Employees</p>
+                <p class="text-3xl font-bold text-white">{{ total_employees }}</p>
+            </div>
+            <div class="w-12 h-12 bg-indigo-600/20 rounded-lg flex items-center justify-center">
+                <svg class="w-6 h-6 text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"></path>
+                </svg>
+            </div>
+        </div>
+    </div>
+
+    <div class="bg-slate-900 border border-slate-700 rounded-xl p-6">
+        <div class="flex items-center justify-between">
+            <div>
+                <p class="text-slate-400 text-sm mb-1">Total Payrolls</p>
+                <p class="text-3xl font-bold text-white">{{ total_payrolls }}</p>
+            </div>
+            <div class="w-12 h-12 bg-green-600/20 rounded-lg flex items-center justify-center">
+                <svg class="w-6 h-6 text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+                </svg>
+            </div>
+        </div>
+    </div>
+
+    <div class="bg-slate-900 border border-slate-700 rounded-xl p-6">
+        <div class="flex items-center justify-between">
+            <div>
+                <p class="text-slate-400 text-sm mb-1">Total Net Salary</p>
+                <p class="text-3xl font-bold text-white">₹{{ total_net|floatformat:0 }}</p>
+            </div>
+            <div class="w-12 h-12 bg-purple-600/20 rounded-lg flex items-center justify-center">
+                <svg class="w-6 h-6 text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                </svg>
+            </div>
+        </div>
+    </div>
+
+    <div class="bg-slate-900 border border-slate-700 rounded-xl p-6">
+        <div class="flex items-center justify-between">
+            <div>
+                <p class="text-slate-400 text-sm mb-1">Average Salary</p>
+                <p class="text-3xl font-bold text-white">₹{{ avg_salary|floatformat:0 }}</p>
+            </div>
+            <div class="w-12 h-12 bg-yellow-600/20 rounded-lg flex items-center justify-center">
+                <svg class="w-6 h-6 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
+                </svg>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Charts Grid -->
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+    <!-- Payroll Trends Over Time -->
+    <div class="bg-slate-900 border border-slate-700 rounded-xl p-6">
+        <h3 class="text-lg font-semibold text-white mb-4">Payroll Trends Over Time</h3>
+        <canvas id="payrollTrendsChart"></canvas>
+    </div>
+
+    <!-- Department-wise Employee Distribution -->
+    <div class="bg-slate-900 border border-slate-700 rounded-xl p-6">
+        <h3 class="text-lg font-semibold text-white mb-4">Employee Distribution by Department</h3>
+        <canvas id="departmentChart"></canvas>
+    </div>
+
+    <!-- Salary Distribution by Department -->
+    <div class="bg-slate-900 border border-slate-700 rounded-xl p-6">
+        <h3 class="text-lg font-semibold text-white mb-4">Average Salary by Department</h3>
+        <canvas id="salaryDeptChart"></canvas>
+    </div>
+
+    <!-- Job Role Distribution -->
+    <div class="bg-slate-900 border border-slate-700 rounded-xl p-6">
+        <h3 class="text-lg font-semibold text-white mb-4">Top Job Roles</h3>
+        <canvas id="jobRoleChart"></canvas>
+    </div>
+</div>
+
+<!-- Full Width Charts -->
+<div class="grid grid-cols-1 gap-6 mb-8">
+    <!-- Recent Payroll Activity -->
+    <div class="bg-slate-900 border border-slate-700 rounded-xl p-6">
+        <h3 class="text-lg font-semibold text-white mb-4">Recent Payroll Activity (Last 6 Months)</h3>
+        <canvas id="recentPayrollChart"></canvas>
+    </div>
+</div>
+
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <!-- Top Allowances -->
+    <div class="bg-slate-900 border border-slate-700 rounded-xl p-6">
+        <h3 class="text-lg font-semibold text-white mb-4">Top Allowance Types</h3>
+        <canvas id="allowanceChart"></canvas>
+    </div>
+
+    <!-- Top Deductions -->
+    <div class="bg-slate-900 border border-slate-700 rounded-xl p-6">
+        <h3 class="text-lg font-semibold text-white mb-4">Top Deduction Types</h3>
+        <canvas id="deductionChart"></canvas>
+    </div>
+</div>
+
+<!-- Chart.js Library -->
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+
+<script>
+    // Chart.js configuration
+    Chart.defaults.color = '#94a3b8';
+    Chart.defaults.borderColor = '#334155';
+    Chart.defaults.backgroundColor = '#1e293b';
+
+    // Color palette for charts
+    const colorPalette = [
+        '#6366f1', // Indigo
+        '#10b981', // Green
+        '#f59e0b', // Amber
+        '#ef4444', // Red
+        '#8b5cf6', // Purple
+        '#06b6d4', // Cyan
+        '#ec4899', // Pink
+        '#14b8a6', // Teal
+        '#f97316', // Orange
+        '#84cc16', // Lime
+        '#3b82f6', // Blue
+        '#a855f7', // Violet
+        '#22c55e', // Emerald
+        '#eab308', // Yellow
+        '#f43f5e'  // Rose
+    ];
+
+    // Function to generate colors dynamically based on count
+    function generateColors(count) {
+        const colors = [];
+        for (let i = 0; i < count; i++) {
+            colors.push(colorPalette[i % colorPalette.length]);
+        }
+        return colors;
+    }
+
+    // Function to generate colors with opacity
+    function generateColorsWithOpacity(count, opacity = 0.8) {
+        const colors = [];
+        for (let i = 0; i < count; i++) {
+            const baseColor = colorPalette[i % colorPalette.length];
+            // Convert hex to rgba
+            const r = parseInt(baseColor.slice(1, 3), 16);
+            const g = parseInt(baseColor.slice(3, 5), 16);
+            const b = parseInt(baseColor.slice(5, 7), 16);
+            colors.push(`rgba(${r}, ${g}, ${b}, ${opacity})`);
+        }
+        return colors;
+    }
+
+    // Payroll Trends Over Time
+    const monthlyLabels = {{ monthly_labels|safe }};
+    const monthlyData = {{ monthly_payroll_data|safe }};
+    
+    const payrollTrendsCtx = document.getElementById('payrollTrendsChart').getContext('2d');
+    new Chart(payrollTrendsCtx, {
+        type: 'line',
+        data: {
+            labels: monthlyLabels,
+            datasets: [
+                {
+                    label: 'Gross Salary',
+                    data: monthlyData.map(d => d.gross_salary),
+                    borderColor: '#6366f1',
+                    backgroundColor: 'rgba(99, 102, 241, 0.1)',
+                    tension: 0.4,
+                    fill: true
+                },
+                {
+                    label: 'Net Salary',
+                    data: monthlyData.map(d => d.net_salary),
+                    borderColor: '#10b981',
+                    backgroundColor: 'rgba(16, 185, 129, 0.1)',
+                    tension: 0.4,
+                    fill: true
+                },
+                {
+                    label: 'Deductions',
+                    data: monthlyData.map(d => d.deductions),
+                    borderColor: '#ef4444',
+                    backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                    tension: 0.4,
+                    fill: true
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: true,
+            plugins: {
+                legend: {
+                    position: 'top',
+                }
+            },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: {
+                        callback: function(value) {
+                            return '₹' + value.toLocaleString('en-IN');
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    // Department-wise Employee Distribution
+    const deptLabels = {{ dept_labels|safe }};
+    const deptCounts = {{ dept_counts|safe }};
+    
+    const deptCtx = document.getElementById('departmentChart').getContext('2d');
+    new Chart(deptCtx, {
+        type: 'doughnut',
+        data: {
+            labels: deptLabels,
+            datasets: [{
+                data: deptCounts,
+                backgroundColor: generateColors(deptLabels.length),
+                borderColor: '#1e293b',
+                borderWidth: 2
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: true,
+            plugins: {
+                legend: {
+                    position: 'bottom',
+                }
+            }
+        }
+    });
+
+    // Salary Distribution by Department
+    const salaryDeptLabels = {{ salary_dept_labels|safe }};
+    const salaryDeptAvg = {{ salary_dept_avg|safe }};
+    
+    const salaryDeptCtx = document.getElementById('salaryDeptChart').getContext('2d');
+    new Chart(salaryDeptCtx, {
+        type: 'bar',
+        data: {
+            labels: salaryDeptLabels,
+            datasets: [{
+                label: 'Average Salary',
+                data: salaryDeptAvg,
+                backgroundColor: generateColorsWithOpacity(salaryDeptLabels.length, 0.8),
+                borderColor: generateColors(salaryDeptLabels.length),
+                borderWidth: 1
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: true,
+            plugins: {
+                legend: {
+                    display: false
+                }
+            },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: {
+                        callback: function(value) {
+                            return '₹' + value.toLocaleString('en-IN');
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    // Job Role Distribution
+    const jobRoleLabels = {{ job_role_labels|safe }};
+    const jobRoleCounts = {{ job_role_counts|safe }};
+    
+    const jobRoleCtx = document.getElementById('jobRoleChart').getContext('2d');
+    new Chart(jobRoleCtx, {
+        type: 'bar',
+        data: {
+            labels: jobRoleLabels,
+            datasets: [{
+                label: 'Employee Count',
+                data: jobRoleCounts,
+                backgroundColor: generateColorsWithOpacity(jobRoleLabels.length, 0.8),
+                borderColor: generateColors(jobRoleLabels.length),
+                borderWidth: 1
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: true,
+            indexAxis: 'y',
+            plugins: {
+                legend: {
+                    display: false
+                }
+            },
+            scales: {
+                x: {
+                    beginAtZero: true
+                }
+            }
+        }
+    });
+
+    // Recent Payroll Activity
+    const recentMonths = {{ recent_months|safe }};
+    const recentGross = {{ recent_gross|safe }};
+    const recentNet = {{ recent_net|safe }};
+    
+    const recentPayrollCtx = document.getElementById('recentPayrollChart').getContext('2d');
+    new Chart(recentPayrollCtx, {
+        type: 'line',
+        data: {
+            labels: recentMonths,
+            datasets: [
+                {
+                    label: 'Gross Salary',
+                    data: recentGross,
+                    borderColor: '#6366f1',
+                    backgroundColor: 'rgba(99, 102, 241, 0.1)',
+                    tension: 0.4,
+                    fill: true
+                },
+                {
+                    label: 'Net Salary',
+                    data: recentNet,
+                    borderColor: '#10b981',
+                    backgroundColor: 'rgba(16, 185, 129, 0.1)',
+                    tension: 0.4,
+                    fill: true
+                }
+            ]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: true,
+            plugins: {
+                legend: {
+                    position: 'top',
+                }
+            },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: {
+                        callback: function(value) {
+                            return '₹' + value.toLocaleString('en-IN');
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    // Top Allowances
+    const allowanceLabels = {{ allowance_labels|safe }};
+    const allowanceAmounts = {{ allowance_amounts|safe }};
+    
+    const allowanceCtx = document.getElementById('allowanceChart').getContext('2d');
+    new Chart(allowanceCtx, {
+        type: 'bar',
+        data: {
+            labels: allowanceLabels,
+            datasets: [{
+                label: 'Total Amount',
+                data: allowanceAmounts,
+                backgroundColor: generateColorsWithOpacity(allowanceLabels.length, 0.8),
+                borderColor: generateColors(allowanceLabels.length),
+                borderWidth: 1
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: true,
+            indexAxis: 'y',
+            plugins: {
+                legend: {
+                    display: false
+                }
+            },
+            scales: {
+                x: {
+                    beginAtZero: true,
+                    ticks: {
+                        callback: function(value) {
+                            return '₹' + value.toLocaleString('en-IN');
+                        }
+                    }
+                }
+            }
+        }
+    });
+
+    // Top Deductions
+    const deductionLabels = {{ deduction_labels|safe }};
+    const deductionAmounts = {{ deduction_amounts|safe }};
+    
+    const deductionCtx = document.getElementById('deductionChart').getContext('2d');
+    new Chart(deductionCtx, {
+        type: 'bar',
+        data: {
+            labels: deductionLabels,
+            datasets: [{
+                label: 'Total Amount',
+                data: deductionAmounts,
+                backgroundColor: generateColorsWithOpacity(deductionLabels.length, 0.8),
+                borderColor: generateColors(deductionLabels.length),
+                borderWidth: 1
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: true,
+            indexAxis: 'y',
+            plugins: {
+                legend: {
+                    display: false
+                }
+            },
+            scales: {
+                x: {
+                    beginAtZero: true,
+                    ticks: {
+                        callback: function(value) {
+                            return '₹' + value.toLocaleString('en-IN');
+                        }
+                    }
+                }
+            }
+        }
+    });
+</script>
+{% endblock %}
+


### PR DESCRIPTION
## PR: Add Reports Dashboard and Payslip Distribution Charts

### Features
- Reports Dashboard (`/reports/`) — HR/Admin analytics with 7 charts (payroll trends, department distribution, salary breakdowns, allowances/deductions)
- Payslip Distribution Modal — Popup charts for individual payslips (salary breakdown, allowances, deductions, composition)

### Technical
- Backend: `reports/views.py` with `reports_dashboard` view and data aggregation, `reports/urls.py`
- Frontend: Chart.js visualizations, shared modal component `payslip_distribution_modal.html`
- Dynamic color system with auto-cycling

### Files Changed
**New:**
- `reports/views.py`
- `reports/urls.py`
- `templates/reports/dashboard.html`
- `templates/employees/payslip_distribution_modal.html`

**Modified:**
- `payroll_manager/urls.py`
- `templates/layout.html`
- `templates/dashboard.html`
- `templates/employees/my_payslips.html`
- `templates/employees/payslip_detail.html`

### Notes
- Reports restricted to HR/Admin users
- Modal dismissible (X button, outside click, `Escape` key)
- Responsive design with dark theme
- Chart.js 4.4.0 via CDN